### PR TITLE
Full Sequencer Mode and Dynamic Preview Sizing

### DIFF
--- a/thumb.html
+++ b/thumb.html
@@ -78,10 +78,36 @@ function setImage(url = null) {
   img.crossOrigin = "Anonymous";
   img.onload = () => {
     inputImage = img;
+    domInputView.width = inputImage.width.toString();
+    domInputView.height = inputImage.height.toString();
+    resizeIOCanvas();
     onChange();
     URL.revokeObjectURL(url);  // Does nothing if not an object URL.
   };
   img.src = url ?? `https://picsum.photos/300?random=${Math.random()}`;
+}
+
+function resizeIOCanvas() {
+  if (inputImage == null) return;
+  let width = inputImage.width.toString();
+  let height = inputImage.height;
+  if (domSize.value == 'full') {
+    domInputView.style.width = '40vw';
+    domInputView.style.aspectRatio = (width / height).toString();
+    domOutputView.style.width = '40vw';
+    domOutputView.style.aspectRatio = (width / height).toString();
+  } else if (domSize.value == 'embed') {
+    domInputView.style.width = '577px';
+    domInputView.style.aspectRatio = (75 / 39).toString();
+    domOutputView.style.width = '577px';
+    domOutputView.style.aspectRatio = (75 / 39).toString();
+  } else {
+    domInputView.style.width = '300px';
+    domInputView.style.aspectRatio = 1;
+    domOutputView.style.width = '300px';
+    domOutputView.style.aspectRatio = 1;
+  }
+  onChange();
 }
 
 function setInputFile(files) {
@@ -234,6 +260,7 @@ function runThumbnailGenerator(img) {
     space: domSpace.value,
     chanWeight: [domChan0.value, domChan1.value, domChan2.value],
     palSize: domCustomPal.checked ? parseInt(domPalNum.value) : 0,
+    aspectRatio: img.width / img.height
   };
   ctxInput.drawImage(img, 0, 0, domInputView.width, domInputView.height);
   outputNotes = [];
@@ -304,7 +331,7 @@ input[type="file"] {
 canvas {
   border: 1px solid #f5f5f5;
   width: 300px;
-  height: 300px;
+  aspect-ratio: 1;
 }
 .view_label {
   width: 100%;
@@ -334,10 +361,11 @@ canvas {
     image.
     <br/><br/>
     <label for="size">Size:</label>
-    <select id="size" onchange="onChange()">
+    <select id="size" onchange="resizeIOCanvas()">
       <option value="normal" selected>Normal</option>
       <option value="small">Small</option>
       <option value="embed">Embed</option>
+      <option value="full">Full</option>
     </select>
     <br/><br/>
     <input type="checkbox" id="wide" checked onchange="onChange()"/>

--- a/thumb.js
+++ b/thumb.js
@@ -25,6 +25,7 @@ function generateThumbnail(image, options, addNote) {
   const space = kSpaces[options.space] ?? kOklab;
   const chanw = options.chanWeight ?? [1, 1, 1];
   const palSize = options.palSize ?? 0;
+  const aspectRatio = options.aspectRatio ?? 1;
 
   let base;
   let h;
@@ -40,6 +41,11 @@ function generateThumbnail(image, options, addNote) {
     h = 39;
     w = 75;
     tmul = 1;
+  } else if (size == 'full') {
+    base = 2 * 12 + 0 /*C2*/;
+    h = 72;
+    w = 72 * aspectRatio;
+    tmul = wide ? 1 : 2;
   } else {
     base = 2 * 12 + 8 /*G#2*/;
     h = 50;


### PR DESCRIPTION
Added support for images that utilize the entire sequencer height and properly scale in width based on the input image. Also made the preview images change based on the mode and for 'Full' mode, based on input image.  'Full' image previews don't have height limits yet, I'll need to come back to that.